### PR TITLE
chore: update CI Go versions to 1.24 and 1.25

### DIFF
--- a/.github/workflows/inspect-code.yaml
+++ b/.github/workflows/inspect-code.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21', '1.22' ]
+        go-version: [ '1.24', '1.25' ]
     steps:
       # Initial setup
       - name: checkout


### PR DESCRIPTION
- Remove Go 1.21 and 1.22 (end of support)
- Add Go 1.24 and 1.25 (currently supported)

Go support policy maintains the latest two major releases. As of November 2025, only 1.24 and 1.25 are actively supported.