### PR TITLE
fix: resolve Dependabot security alerts (undici/picomatch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,16 +48,13 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -358,16 +355,6 @@
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -980,9 +967,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "husky": "^9.1.7",
     "semantic-release": "^25.0.2"
   },
+  "overrides": {
+    "@actions/http-client": {
+      "undici": "^6.24.0"
+    }
+  },
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary
- Dependabot で検出されていた dev 依存（semantic-release 経由）の脆弱性を解消
- `@actions/http-client` が transitive で参照していた `undici@5.29.0` を `^6.24.0` に強制更新

## 修正内容
| Alert # | Package | Old Version | New Version | CVE | Severity |
|---------|---------|-------------|-------------|-----|----------|
| #51 | undici | 5.29.0 | 6.25.0 | CVE-2026-1525 (HTTP Request/Response Smuggling) | medium |
| #52 | undici | 5.29.0 | 6.25.0 | CVE-2026-1527 (CRLF Injection) | medium |
| #57 | picomatch | (既に 2.3.2 / 4.0.4 でパッチ済み) | — | CVE-2026-33672 | medium |

## 修正方針
- `package.json` に `overrides` を追加し、`@actions/http-client` 配下の `undici` のみを `^6.24.0` に強制
  - 上位の `semantic-release@25` を更新するだけでは `@actions/http-client@2.2.3` の `undici@^5.25.4` 制約により脆弱バージョンが残るため
  - `node_modules/undici@7.24.1`（`@semantic-release/github` 経由）には影響を与えない最小スコープのオーバーライド
- picomatch は `package.json` のみが既に `semantic-release@^25.0.2` に更新されており lockfile が古かったため、`npm install` で同期した結果ツリー全体がパッチ済みバージョン（2.3.2 / 4.0.4）に揃った

## 影響範囲
- すべて `devDependencies` 配下の transitive 依存（リリース自動化用）
- 本ライブラリ（Go ランタイム）には影響なし

## テスト
- [x] `npm audit` で対象 3 件の脆弱性が解消されたことを確認
  - 残る 2 件（`brace-expansion`, `picomatch@4.0.3`）は `node_modules/npm/` 配下に同梱されているもので Dependabot 対象外
- [x] `npm ls undici` で `@actions/http-client` 配下が `undici@6.25.0` になったことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)