### PR TITLE
feat: add WILD, ZPG, ZPGAG, ZPGPT symbols

### DIFF
--- a/api/common/consts/symbol.go
+++ b/api/common/consts/symbol.go
@@ -83,6 +83,14 @@ const (
 	SymbolSUI = Symbol("SUI")
 	// SymbolSUIJPY ...
 	SymbolSUIJPY = Symbol("SUI_JPY")
+	// SymbolWILD ...
+	SymbolWILD = Symbol("WILD")
+	// SymbolZPG ...
+	SymbolZPG = Symbol("ZPG")
+	// SymbolZPGAG ...
+	SymbolZPGAG = Symbol("ZPGAG")
+	// SymbolZPGPT ...
+	SymbolZPGPT = Symbol("ZPGPT")
 	// SymbolNONE ...
 	SymbolNONE = Symbol("")
 )
@@ -125,6 +133,10 @@ var allSymbols = []Symbol{
 	SymbolCHZ,
 	SymbolSUI,
 	SymbolSUIJPY,
+	SymbolWILD,
+	SymbolZPG,
+	SymbolZPGAG,
+	SymbolZPGPT,
 }
 
 func (c *Symbol) UnmarshalJSON(d []byte) error {


### PR DESCRIPTION
## Summary
- GMO Coin API 更新履歴 [2026-03-21](https://api.coin.z.com/docs/#2026-03-21) — `WILD`（ワイルダーワールド／現物取引）を追加
- GMO Coin API 更新履歴 [2026-04-18](https://api.coin.z.com/docs/#2026-04-18-new) — 資産残高 Response 用に `ZPG` / `ZPGAG` / `ZPGPT`（ジパングコイン／シルバー／プラチナ・販売所）を追加
- いずれも `api/common/consts/symbol.go` の定数および `allSymbols` リストへ追加

## Test plan
- [x] `go build ./...`
- [ ] `go test ./...`
- [ ] 既存利用者の Symbol 列挙への影響確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)