### PR TITLE
fix: bump npm to ^11.14.0 to resolve ip-address XSS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.0.tgz",
+      "integrity": "sha512-6jfZzqK8EfWGnTeZQe+bgMx4IgiEZn7k1eM4GE8SE81B3iYch52dVSMO1hC2OnNbFLIwzvwUkUxsOOcUPG2XIw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2817,8 +2817,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -2842,11 +2842,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.6",
-        "libnpmexec": "^10.2.6",
-        "libnpmfund": "^7.0.20",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.6",
+        "libnpmpack": "^9.1.7",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -2964,7 +2964,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
+      "version": "9.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3012,7 +3012,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3426,7 +3426,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -3649,7 +3649,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3731,12 +3731,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.6",
+      "version": "8.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3750,13 +3750,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.6",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3773,12 +3773,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.20",
+      "version": "7.0.21",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3"
+        "@npmcli/arborist": "^9.5.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3798,12 +3798,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.6",
+      "version": "9.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4434,12 +4434,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@actions/http-client": {
       "undici": "^6.24.0"
     },
-    "npm": "^11.13.0"
+    "npm": "^11.14.0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
## Summary
- Dependabot alert #70 で検出された `ip-address` の XSS 脆弱性を解消

## 修正内容
| Alert # | Package | Old | New | CVE |
|---------|---------|-----|-----|-----|
| #70 | `npm` (override) | ^11.13.0 | ^11.14.0 | CVE-2026-42338 |
| #70 | `ip-address` (bundled in npm) | 10.1.0 | 10.1.1 | GHSA-v2v4-37r5-5v8g |
| - | `socks` (bundled in npm) | 2.8.7 | 2.8.8 | - |

## 修正方針
- 脆弱な `ip-address@10.1.0` は `semantic-release` → `npm` に bundled された `socks` 経由の transitive dependency
- `ip-address` を直接 override しても `npm` の bundled dependency には効かないため、`npm` 自体のバージョンを `^11.14.0` にバンプして bundled の `socks@2.8.8` / `ip-address@10.1.1` を取り込む方針を採用
- 過去の `picomatch` 修正（#90）と同じパターン

## 影響度評価
- 脆弱性は `Address6.group()` / `link()` / `spanAll()` / `AddressError.parseMessage` の HTML 出力 API に限定
- 本リポジトリは Go ライブラリで、これらの API は実行経路に登場しない
- npm パッケージは devDependencies（CI のリリース処理用）であり、エンドユーザーへの影響なし

## Test plan
- [x] `npm install` 成功
- [x] `npm audit` で 0 vulnerabilities 確認
- [x] `node_modules/npm/node_modules/ip-address/package.json` で 10.1.1 にアップデート済みを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)