### PR TITLE
ci: allow dependabot to trigger Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Dependabot が起点の PR で `claude-code-action` が `Workflow initiated by non-human actor: dependabot (type: Bot)` エラーで停止していた問題を修正
- `.github/workflows/claude-code-review.yml` の `with:` に `allowed_bots: 'dependabot[bot]'` を追加し、Dependabot の PR でもレビューが走るようにする
- `claude.yml` (オンデマンド側) はコメント駆動のため変更不要

## Note
Dependabot が起動した workflow は GitHub の仕様で通常の `secrets` を読めないため、レビューを実際に動かすには **Settings → Secrets and variables → Dependabot** に `CLAUDE_CODE_OAUTH_TOKEN` を別途登録する必要がある。

## Test plan
- [ ] このブランチに対する Claude Code Review ワークフローが従来通り成功する
- [ ] マージ後、新しい Dependabot PR で `non-human actor` エラーが出ないことを確認
- [ ] Dependabot secrets に `CLAUDE_CODE_OAUTH_TOKEN` を登録した上で、Dependabot PR にレビューコメントが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)