### PR TITLE
ci: pin GitHub Actions to commit SHAs and update to latest

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'dependabot[bot]'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,13 +29,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/inspect-code.yaml
+++ b/.github/workflows/inspect-code.yaml
@@ -18,9 +18,9 @@ jobs:
     steps:
       # Initial setup
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
@@ -38,4 +38,4 @@ jobs:
         run: go test ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: Install dependencies


### PR DESCRIPTION
## 概要

GitHub Actions のサプライチェーン攻撃対策として、ワークフローで使用している各アクションをコミット SHA でピン留めし、合わせて最新バージョンに更新する。

## 変更内容

- `actions/checkout` を `v4` → `v6.0.2` (`de0fac2`) に更新
- `anthropics/claude-code-action` を `v1` → `v1.0.123` (`51ea8ea`) に更新
- `actions/setup-go` を `v5` → `v6.4.0` (`4a36011`) に更新
- `golangci/golangci-lint-action` を `v9` → `v9.2.0` (`1e7e51e`) に更新
- `actions/setup-node` を `v4` → `v6.4.0` (`48b55a0`) に更新
- すべてのタグ参照をコミット SHA ピン留めに変更し、バージョン情報はコメントで保持

## 影響範囲 / 注意点

- ワークフローの挙動自体に変更はないが、各アクションのメジャー/マイナーアップデートを含むため CI 上での動作差異が発生する可能性あり
- 今後のバージョン追従には Dependabot の `package-ecosystem: github-actions` 設定を推奨

## 動作確認

未実施（CI 上で実行される）