### PR TITLE
refactor: REST クライアントで RestAPIBase を埋め込みフィールド化

### DIFF
--- a/api/private/rest/account_assets.go
+++ b/api/private/rest/account_assets.go
@@ -17,12 +17,12 @@ type AccountAssets interface {
 
 func newAccountAssets(apiKey, secretKey string) accountAssets {
 	return accountAssets{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type accountAssets struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // AccountAssets ...
@@ -32,7 +32,7 @@ func (a *accountAssets) AccountAssets() (*model.AccountAssetsRes, error) {
 
 // AccountAssetsWithContext ...
 func (a *accountAssets) AccountAssetsWithContext(ctx context.Context) (*model.AccountAssetsRes, error) {
-	res, err := a.apiBase.Get(ctx, url.Values{}, "/v1/account/assets")
+	res, err := a.Get(ctx, url.Values{}, "/v1/account/assets")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/account_margin.go
+++ b/api/private/rest/account_margin.go
@@ -17,12 +17,12 @@ type AccountMargin interface {
 
 func newAccountMargin(apiKey, secretKey string) accountMargin {
 	return accountMargin{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type accountMargin struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // AccountMargin ...
@@ -32,7 +32,7 @@ func (a *accountMargin) AccountMargin() (*model.AccountMarginRes, error) {
 
 // AccountMarginWithContext ...
 func (a *accountMargin) AccountMarginWithContext(ctx context.Context) (*model.AccountMarginRes, error) {
-	res, err := a.apiBase.Get(ctx, url.Values{}, "/v1/account/margin")
+	res, err := a.Get(ctx, url.Values{}, "/v1/account/margin")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/active_orders.go
+++ b/api/private/rest/active_orders.go
@@ -18,12 +18,12 @@ type ActiveOrders interface {
 
 func newActiveOrders(apiKey, secretKey string) activeOrders {
 	return activeOrders{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type activeOrders struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // ActiveOrders ...
@@ -37,7 +37,7 @@ func (c activeOrders) ActiveOrdersWithContext(ctx context.Context, symbol consts
 		"symbol": {string(symbol)},
 		"page":   {fmt.Sprint(pageNo)},
 	}
-	res, err := c.apiBase.Get(ctx, req, "/v1/activeOrders")
+	res, err := c.Get(ctx, req, "/v1/activeOrders")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/cancel_order.go
+++ b/api/private/rest/cancel_order.go
@@ -16,12 +16,12 @@ type CancelOrder interface {
 
 func newCancelOrder(apiKey, secretKey string) cancelOrder {
 	return cancelOrder{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type cancelOrder struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // CancelOrder ...
@@ -32,7 +32,7 @@ func (c *cancelOrder) CancelOrder(orderID int64) error {
 // CancelOrderWithContext ...
 func (c *cancelOrder) CancelOrderWithContext(ctx context.Context, orderID int64) error {
 	req := model.CancelOrderReq{OrderID: orderID}
-	res, err := c.apiBase.Post(ctx, req, "/v1/cancelOrder")
+	res, err := c.Post(ctx, req, "/v1/cancelOrder")
 	if err != nil {
 		return err
 	}

--- a/api/private/rest/change_losscut_price.go
+++ b/api/private/rest/change_losscut_price.go
@@ -17,12 +17,12 @@ type ChangeLosscutPrice interface {
 
 func newChangeLosscutPrice(apiKey, secretKey string) changeLosscutPrice {
 	return changeLosscutPrice{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type changeLosscutPrice struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // ChangeLosscutPrice ...
@@ -37,7 +37,7 @@ func (c *changeLosscutPrice) ChangeLosscutPriceWithContext(ctx context.Context, 
 		LosscutPrice: losscutPrice,
 	}
 
-	res, err := c.apiBase.Post(ctx, request, "/v1/changeLosscutPrice")
+	res, err := c.Post(ctx, request, "/v1/changeLosscutPrice")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/change_order.go
+++ b/api/private/rest/change_order.go
@@ -17,12 +17,12 @@ type ChangeOrder interface {
 
 func newChangeOrder(apiKey, secretKey string) changeOrder {
 	return changeOrder{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type changeOrder struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // ChangeOrder ...
@@ -37,7 +37,7 @@ func (c *changeOrder) ChangeOrderWithContext(ctx context.Context, orderID int64,
 		Price:   price,
 	}
 
-	res, err := c.apiBase.Post(ctx, request, "/v1/changeOrder")
+	res, err := c.Post(ctx, request, "/v1/changeOrder")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/close_bulk_order.go
+++ b/api/private/rest/close_bulk_order.go
@@ -18,12 +18,12 @@ type CloseBulkOrder interface {
 
 func newCloseBulkOrder(apiKey, secretKey string) closeBulkOrder {
 	return closeBulkOrder{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type closeBulkOrder struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // CloseBulkOrder ...
@@ -44,7 +44,7 @@ func (c *closeBulkOrder) CloseBulkOrderWithContext(ctx context.Context, symbol c
 		request.Price = &price
 	}
 
-	res, err := c.apiBase.Post(ctx, request, "/v1/closeBulkOrder")
+	res, err := c.Post(ctx, request, "/v1/closeBulkOrder")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/close_order.go
+++ b/api/private/rest/close_order.go
@@ -18,12 +18,12 @@ type CloseOrder interface {
 
 func newCloseOrder(apiKey, secretKey string) closeOrder {
 	return closeOrder{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type closeOrder struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // CloseOrder ...
@@ -47,7 +47,7 @@ func (c *closeOrder) CloseOrderWithContext(ctx context.Context, positionID int64
 		req.Price = &price
 	}
 
-	res, err := c.apiBase.Post(ctx, req, "/v1/closeOrder")
+	res, err := c.Post(ctx, req, "/v1/closeOrder")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/executions.go
+++ b/api/private/rest/executions.go
@@ -22,12 +22,12 @@ type Executions interface {
 
 func newExecutions(apiKey, secretKey string) executions {
 	return executions{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type executions struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // ExecutionsByOrderID ...
@@ -67,7 +67,7 @@ func (e *executions) ExecutionsWithContext(ctx context.Context, orderID, executi
 		param.Set("executionId", strconv.FormatInt(executionID, 10))
 	}
 
-	res, err := e.apiBase.Get(ctx, param, "/v1/executions")
+	res, err := e.Get(ctx, param, "/v1/executions")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/last_executions.go
+++ b/api/private/rest/last_executions.go
@@ -19,12 +19,12 @@ type LastExecutions interface {
 
 func newLastExecutions(apiKey, secretKey string) lastExecutions {
 	return lastExecutions{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type lastExecutions struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // LastExecutions ...
@@ -46,7 +46,7 @@ func (l *lastExecutions) LastExecutionsWithContext(ctx context.Context, symbol c
 		param.Set("count", strconv.Itoa(count))
 	}
 
-	res, err := l.apiBase.Get(ctx, param, "/v1/latestExecutions")
+	res, err := l.Get(ctx, param, "/v1/latestExecutions")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/open_position.go
+++ b/api/private/rest/open_position.go
@@ -18,12 +18,12 @@ type OpenPositions interface {
 
 func newOpenPositions(apiKey, secretKey string) openPositions {
 	return openPositions{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type openPositions struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // OpenPositions ...
@@ -37,7 +37,7 @@ func (c *openPositions) OpenPositionsWithContext(ctx context.Context, symbol con
 		"symbol": {string(symbol)},
 		"page":   {fmt.Sprint(pageNo)},
 	}
-	res, err := c.apiBase.Get(ctx, req, "/v1/openPositions")
+	res, err := c.Get(ctx, req, "/v1/openPositions")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/order.go
+++ b/api/private/rest/order.go
@@ -18,12 +18,12 @@ type Order interface {
 
 func newOrder(apiKey, secretKey string) order {
 	return order{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type order struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Order ...
@@ -44,7 +44,7 @@ func (c *order) OrderWithContext(ctx context.Context, symbol consts.Symbol, side
 		req.Price = &price
 	}
 
-	res, err := c.apiBase.Post(ctx, req, "/v1/order")
+	res, err := c.Post(ctx, req, "/v1/order")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/orders.go
+++ b/api/private/rest/orders.go
@@ -18,12 +18,12 @@ type Orders interface {
 
 func newOrders(apiKey, secretKey string) orders {
 	return orders{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type orders struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Orders ...
@@ -37,7 +37,7 @@ func (o *orders) OrdersWithContext(ctx context.Context, orderID int64) (*model.O
 		"orderId": {strconv.FormatInt(orderID, 10)},
 	}
 
-	res, err := o.apiBase.Get(ctx, param, "/v1/orders")
+	res, err := o.Get(ctx, param, "/v1/orders")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/position_summary.go
+++ b/api/private/rest/position_summary.go
@@ -18,12 +18,12 @@ type PositionSummary interface {
 
 func newPositionSummary(apiKey, secretKey string) positionSummary {
 	return positionSummary{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type positionSummary struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // PositionSummary ...
@@ -37,7 +37,7 @@ func (p *positionSummary) PositionSummaryWithContext(ctx context.Context, symbol
 		"symbol": {string(symbol)},
 	}
 
-	res, err := p.apiBase.Get(ctx, param, "/v1/positionSummary")
+	res, err := p.Get(ctx, param, "/v1/positionSummary")
 	if err != nil {
 		return nil, err
 	}

--- a/api/private/rest/ws_auth.go
+++ b/api/private/rest/ws_auth.go
@@ -20,12 +20,12 @@ type WSAuth interface {
 
 func newWSAuth(apiKey, secretKey string) wsAuth {
 	return wsAuth{
-		apiBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
+		RestAPIBase: api.NewPrivateRestAPIBase(apiKey, secretKey),
 	}
 }
 
 type wsAuth struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // CreateWSAuthToken ...
@@ -35,7 +35,7 @@ func (w *wsAuth) CreateWSAuthToken() (string, error) {
 
 // CreateWSAuthTokenWithContext ...
 func (w *wsAuth) CreateWSAuthTokenWithContext(ctx context.Context) (string, error) {
-	res, err := w.apiBase.Post(ctx, url.Values{}, "/v1/ws-auth")
+	res, err := w.Post(ctx, url.Values{}, "/v1/ws-auth")
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +59,7 @@ func (w *wsAuth) ExtendWSAuthToken(token string) error {
 // ExtendWSAuthTokenWithContext ...
 func (w *wsAuth) ExtendWSAuthTokenWithContext(ctx context.Context, token string) error {
 	req := model.WSAuthReq{Token: token}
-	res, err := w.apiBase.Put(ctx, req, "/v1/ws-auth")
+	res, err := w.Put(ctx, req, "/v1/ws-auth")
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (w *wsAuth) RevokeWSAuthToken(token string) error {
 // RevokeWSAuthTokenWithContext ...
 func (w *wsAuth) RevokeWSAuthTokenWithContext(ctx context.Context, token string) error {
 	req := model.WSAuthReq{Token: token}
-	res, err := w.apiBase.Delete(ctx, req, "/v1/ws-auth")
+	res, err := w.Delete(ctx, req, "/v1/ws-auth")
 	if err != nil {
 		return err
 	}

--- a/api/public/rest/klines.go
+++ b/api/public/rest/klines.go
@@ -17,12 +17,12 @@ type KLines interface {
 
 func newKLines() kLines {
 	return kLines{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type kLines struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // KLines ...
@@ -38,7 +38,7 @@ func (k *kLines) KLinesWithContext(ctx context.Context, symbol consts.Symbol, in
 		"date":     {date},
 	}
 
-	res, err := k.apiBase.Get(ctx, param, "/v1/klines")
+	res, err := k.Get(ctx, param, "/v1/klines")
 	if err != nil {
 		return nil, err
 	}

--- a/api/public/rest/orderbooks.go
+++ b/api/public/rest/orderbooks.go
@@ -18,12 +18,12 @@ type OrderBooks interface {
 
 func newOrderBooks() orderBooks {
 	return orderBooks{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type orderBooks struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // OrderBooks ...
@@ -37,7 +37,7 @@ func (o *orderBooks) OrderBooksWithContext(ctx context.Context, symbol consts.Sy
 		"symbol": {string(symbol)},
 	}
 
-	res, err := o.apiBase.Get(ctx, param, "/v1/orderbooks")
+	res, err := o.Get(ctx, param, "/v1/orderbooks")
 	if err != nil {
 		return nil, err
 	}

--- a/api/public/rest/status.go
+++ b/api/public/rest/status.go
@@ -17,12 +17,12 @@ type Status interface {
 
 func newStatus() status {
 	return status{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type status struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Status ...
@@ -32,7 +32,7 @@ func (s *status) Status() (*model.StatusRes, error) {
 
 // StatusWithContext ...
 func (s *status) StatusWithContext(ctx context.Context) (*model.StatusRes, error) {
-	res, err := s.apiBase.Get(ctx, url.Values{}, "/v1/status")
+	res, err := s.Get(ctx, url.Values{}, "/v1/status")
 	if err != nil {
 		return nil, err
 	}

--- a/api/public/rest/symbols.go
+++ b/api/public/rest/symbols.go
@@ -17,12 +17,12 @@ type Symbols interface {
 
 func newSymbols() symbols {
 	return symbols{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type symbols struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Symbols ...
@@ -32,7 +32,7 @@ func (t *symbols) Symbols() (*model.SymbolsRes, error) {
 
 // SymbolsWithContext ...
 func (t *symbols) SymbolsWithContext(ctx context.Context) (*model.SymbolsRes, error) {
-	res, err := t.apiBase.Get(ctx, url.Values{}, "/v1/symbols")
+	res, err := t.Get(ctx, url.Values{}, "/v1/symbols")
 	if err != nil {
 		return nil, err
 	}

--- a/api/public/rest/ticker.go
+++ b/api/public/rest/ticker.go
@@ -18,12 +18,12 @@ type Ticker interface {
 
 func newTicker() ticker {
 	return ticker{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type ticker struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Ticker ...
@@ -39,7 +39,7 @@ func (t *ticker) TickerWithContext(ctx context.Context, symbol consts.Symbol) (*
 		param.Set("symbol", string(symbol))
 	}
 
-	res, err := t.apiBase.Get(ctx, param, "/v1/ticker")
+	res, err := t.Get(ctx, param, "/v1/ticker")
 	if err != nil {
 		return nil, err
 	}

--- a/api/public/rest/trades.go
+++ b/api/public/rest/trades.go
@@ -19,12 +19,12 @@ type Trades interface {
 
 func newTrades() trades {
 	return trades{
-		apiBase: api.NewRestAPIBase(),
+		RestAPIBase: api.NewRestAPIBase(),
 	}
 }
 
 type trades struct {
-	apiBase api.RestAPIBase
+	api.RestAPIBase
 }
 
 // Trades ...
@@ -46,7 +46,7 @@ func (t *trades) TradesWithContext(ctx context.Context, symbol consts.Symbol, pa
 		param.Set("count", strconv.FormatInt(count, 10))
 	}
 
-	res, err := t.apiBase.Get(ctx, param, "/v1/trades")
+	res, err := t.Get(ctx, param, "/v1/trades")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

各 REST クライアントの `apiBase api.RestAPIBase` という名前付きフィールドを、埋め込みフィールド `api.RestAPIBase` に変更し、`c.apiBase.Get(...)` のような呼び出しを促進メソッド経由の `c.Get(...)` に統一します。

- 対象: REST クライアント 21 ファイル（public 6 + private 15）
- 変更内容（各ファイル共通）:
  - 構造体: `apiBase api.RestAPIBase` → `api.RestAPIBase`（埋め込み）
  - コンストラクタ: `apiBase: api.New...` → `RestAPIBase: api.New...`
  - メソッド本体: `x.apiBase.Get/Post/Put/Delete(...)` → `x.Get/Post/Put/Delete(...)`
- **挙動の変更なし**。`Get/Post/Put/Delete` は埋め込みにより促進メソッドになりますが、公開している `Client` インターフェースには含まれないため、外部利用者から見える API サーフェスは変わりません。

> 注: 本 PR は #97（SHOULD 対応）にスタックしています。ベースを `refactor/should-fixes` に設定しているため、差分は本リファクタ（21 ファイル / +65 -65）のみです。#97 マージ時に自動で `main` へ付け替わります。

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run`（0 issues）
- [ ] CI で全チェックが green であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
