### PR TITLE
feat: add Stream method and fix RetrieveStream goroutine leak

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,7 @@ if err != nil {
 }
 for {
     select {
-    case v := <-client.Receive():
+    case v := <-client.Stream():
         log.Printf("msg:%+v", v)
     case <-time.After(180 * time.Second):
         log.Println("timeout...")
@@ -115,7 +115,7 @@ if err := client.Subscribe(); err != nil {
 timeoutCnt := 0
 for {
     select {
-    case v := <-client.Receive():
+    case v := <-client.Stream():
         log.Printf("msg:%+v\n", v)
     case <-time.After(180 * time.Second):
         log.Println("timeout...")

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ if err != nil {
 }
 for {
     select {
-    case v := <-client.Receive():
+    case v := <-client.Stream():
         log.Printf("msg:%+v", v)
     case <-time.After(180 * time.Second):
         log.Println("timeout...")
@@ -129,7 +129,7 @@ if err := client.Subscribe(); err != nil {
 timeoutCnt := 0
 for {
     select {
-    case v := <-client.Receive():
+    case v := <-client.Stream():
         log.Printf("msg:%+v\n", v)
     case <-time.After(180 * time.Second):
         log.Println("timeout...")

--- a/api/internal/api/functions.go
+++ b/api/internal/api/functions.go
@@ -1,32 +1,64 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
 	"github.com/ijufumi/gogmocoin/v2/api/common/configuration"
 )
 
-// RetrieveStream ...
-func RetrieveStream[T any](name string, rawStream <-chan []byte) <-chan *T {
+// RetrieveStream unmarshals raw WebSocket payloads from rawStream into typed *T
+// values delivered on the returned channel. The backing goroutine terminates
+// (and closes the returned channel) when ctx is cancelled or rawStream is
+// closed, so it never leaks across a Subscribe/Unsubscribe cycle.
+func RetrieveStream[T any](ctx context.Context, name string, rawStream <-chan []byte) <-chan *T {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	stream := make(chan *T, 10)
 	go func() {
+		defer close(stream)
 		for {
-			v := <-rawStream
-			if v == nil {
+			select {
+			case <-ctx.Done():
 				return
+			case v, ok := <-rawStream:
+				if !ok {
+					return
+				}
+				if configuration.IsDebug() {
+					log.Printf("[%v] received:%v", name, string(v))
+				}
+				res := new(T)
+				if err := json.Unmarshal(v, res); err != nil {
+					log.Printf("[%v] unmarshal error:%v", name, err)
+					continue
+				}
+				select {
+				case stream <- res:
+				case <-ctx.Done():
+					return
+				}
 			}
-			if configuration.IsDebug() {
-				log.Printf("[%v] received:%v", name, string(v))
-			}
-			res := new(T)
-			err := json.Unmarshal(v, res)
-			if err != nil {
-				log.Printf("[%v] unmarshal error:%v", name, err)
-				continue
-			}
-			stream <- res
 		}
 	}()
 	return stream
+}
+
+// RetrieveStreamOnce returns the typed stream for the current Subscribe session,
+// creating it on first use and memoizing it so that repeated calls share a
+// single backing goroutine instead of spawning competing readers of the raw
+// stream. The memo is cleared on every Subscribe (see WSAPIBase.start), so a
+// Subscribe -> Unsubscribe -> Subscribe cycle yields a fresh, live stream rather
+// than the previous (already closed) one.
+func RetrieveStreamOnce[T any](c *WSAPIBase, name string) <-chan *T {
+	c.streamMu.Lock()
+	defer c.streamMu.Unlock()
+	if s, ok := c.typedStream.(<-chan *T); ok {
+		return s
+	}
+	s := RetrieveStream[T](c.ctx, name, c.stream)
+	c.typedStream = s
+	return s
 }

--- a/api/internal/api/functions_test.go
+++ b/api/internal/api/functions_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sample struct {
+	Name string `json:"name"`
+}
+
+// TestRetrieveStream_UnmarshalsAndDelivers verifies that raw payloads are
+// decoded into typed values and delivered on the returned channel.
+func TestRetrieveStream_UnmarshalsAndDelivers(t *testing.T) {
+	raw := make(chan []byte, 1)
+	out := RetrieveStream[sample](context.Background(), "sample", raw)
+
+	raw <- []byte(`{"name":"btc"}`)
+
+	select {
+	case v := <-out:
+		require.NotNil(t, v)
+		assert.Equal(t, "btc", v.Name)
+	case <-time.After(time.Second):
+		t.Fatal("expected a value")
+	}
+}
+
+// TestRetrieveStream_SkipsInvalidPayload ensures a malformed payload is dropped
+// without terminating the stream.
+func TestRetrieveStream_SkipsInvalidPayload(t *testing.T) {
+	raw := make(chan []byte, 2)
+	out := RetrieveStream[sample](context.Background(), "sample", raw)
+
+	raw <- []byte(`not-json`)
+	raw <- []byte(`{"name":"eth"}`)
+
+	select {
+	case v := <-out:
+		require.NotNil(t, v)
+		assert.Equal(t, "eth", v.Name)
+	case <-time.After(time.Second):
+		t.Fatal("expected the valid value after skipping the invalid one")
+	}
+}
+
+// TestRetrieveStream_ContextCancelClosesChannel is the core leak-fix guarantee:
+// cancelling the context terminates the goroutine and closes the output, even
+// though the raw stream is never closed.
+func TestRetrieveStream_ContextCancelClosesChannel(t *testing.T) {
+	raw := make(chan []byte) // never closed, mirroring WSAPIBase.stream
+	ctx, cancel := context.WithCancel(context.Background())
+	out := RetrieveStream[sample](ctx, "sample", raw)
+
+	cancel()
+
+	select {
+	case _, ok := <-out:
+		assert.False(t, ok, "channel should be closed after context cancellation")
+	case <-time.After(time.Second):
+		t.Fatal("goroutine did not terminate after context cancellation")
+	}
+}
+
+// TestRetrieveStreamOnce_MemoizesWithinSession verifies repeated calls return
+// the same channel so the raw stream is not split across competing readers.
+func TestRetrieveStreamOnce_MemoizesWithinSession(t *testing.T) {
+	base := NewWSAPIBase(testRequestFactory)
+	base.initContext(context.Background())
+
+	first := RetrieveStreamOnce[sample](base, "sample")
+	second := RetrieveStreamOnce[sample](base, "sample")
+
+	assert.Equal(t, first, second, "expected the memoized stream to be reused")
+}
+
+// TestRetrieveStreamOnce_FreshAfterResubscribe verifies the Subscribe ->
+// Unsubscribe -> Subscribe lifecycle: resetTypedStream (called from start on a
+// new session) drops the old, already-closed stream so a live one is built.
+func TestRetrieveStreamOnce_FreshAfterResubscribe(t *testing.T) {
+	base := NewWSAPIBase(testRequestFactory)
+
+	// Session 1.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	base.initContext(ctx1)
+	first := RetrieveStreamOnce[sample](base, "sample")
+
+	// Unsubscribe: the session context is cancelled and the stream closes.
+	cancel1()
+	select {
+	case _, ok := <-first:
+		assert.False(t, ok, "session 1 stream should close on unsubscribe")
+	case <-time.After(time.Second):
+		t.Fatal("session 1 stream did not close")
+	}
+
+	// Session 2: start() resets the memo before spawning new goroutines.
+	base.resetTypedStream()
+	ctx2 := context.Background()
+	base.initContext(ctx2)
+	second := RetrieveStreamOnce[sample](base, "sample")
+
+	assert.NotEqual(t, first, second, "expected a fresh stream for the new session")
+
+	// The new stream must be live: a payload is delivered.
+	base.stream <- []byte(`{"name":"xrp"}`)
+	select {
+	case v := <-second:
+		require.NotNil(t, v)
+		assert.Equal(t, "xrp", v.Name)
+	case <-time.After(time.Second):
+		t.Fatal("session 2 stream is not live")
+	}
+}

--- a/api/internal/api/ws_api_base.go
+++ b/api/internal/api/ws_api_base.go
@@ -49,6 +49,10 @@ type WSAPIBase struct {
 	unsubscribeFunc func() error
 	stream          chan []byte
 	msgStream       chan msgRequest
+	// streamMu guards typedStream, the per-session memoized typed stream built
+	// lazily by RetrieveStreamOnce.
+	streamMu    sync.Mutex
+	typedStream any
 }
 
 type msgRequest struct {
@@ -87,6 +91,10 @@ func (c *WSAPIBase) start(ctx context.Context) {
 	defer c.startMu.Unlock()
 	if c.isStopped() {
 		c.initContext(ctx)
+		// Drop any typed stream from a previous session: it is bound to the old
+		// (now cancelled) context and its channel is already closed, so the next
+		// RetrieveStreamOnce must build a fresh one against the new context.
+		c.resetTypedStream()
 		// Move out of the stopped state while still holding the lock so that a
 		// concurrent Subscribe observes a non-stopped state and does not spawn a
 		// second goroutine pair. The receive goroutine transitions to Connected
@@ -278,6 +286,14 @@ func (c *WSAPIBase) dial() error {
 // Stream ...
 func (c *WSAPIBase) Stream() <-chan []byte {
 	return c.stream
+}
+
+// resetTypedStream clears the memoized typed stream so the next
+// RetrieveStreamOnce rebuilds it for the current session.
+func (c *WSAPIBase) resetTypedStream() {
+	c.streamMu.Lock()
+	c.typedStream = nil
+	c.streamMu.Unlock()
 }
 
 // close is ...

--- a/api/private/ws/execution_events.go
+++ b/api/private/ws/execution_events.go
@@ -12,6 +12,9 @@ type ExecutionEvents interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.ExecutionEventsRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.ExecutionEventsRes
 }
 
@@ -42,6 +45,11 @@ func (c *executionEvents) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *executionEvents) Stream() <-chan *model.ExecutionEventsRes {
+	return api.RetrieveStreamOnce[model.ExecutionEventsRes](c.apiBase.WS(), "ExecutionEvents")
+}
+
+// Deprecated: use Stream instead.
 func (c *executionEvents) Receive() <-chan *model.ExecutionEventsRes {
-	return api.RetrieveStream[model.ExecutionEventsRes]("ExecutionEvents", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/private/ws/internal/ws_api_base.go
+++ b/api/private/ws/internal/ws_api_base.go
@@ -72,6 +72,12 @@ func (w *PrivateWSAPIBase) Stream() <-chan []byte {
 	return w.wsAPIBase.Stream()
 }
 
+// WS exposes the underlying WSAPIBase so generic helpers such as
+// api.RetrieveStreamOnce can access the shared raw stream and session state.
+func (w *PrivateWSAPIBase) WS() *api.WSAPIBase {
+	return w.wsAPIBase
+}
+
 func (w *PrivateWSAPIBase) automaticExtension() {
 	ticker := time.NewTicker(50 * time.Minute)
 	go func() {

--- a/api/private/ws/order_events.go
+++ b/api/private/ws/order_events.go
@@ -12,6 +12,9 @@ type OrderEvents interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.OrderEventsRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.OrderEventsRes
 }
 
@@ -42,6 +45,11 @@ func (c *orderEvents) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *orderEvents) Stream() <-chan *model.OrderEventsRes {
+	return api.RetrieveStreamOnce[model.OrderEventsRes](c.apiBase.WS(), "OrderEvents")
+}
+
+// Deprecated: use Stream instead.
 func (c *orderEvents) Receive() <-chan *model.OrderEventsRes {
-	return api.RetrieveStream[model.OrderEventsRes]("OrderEvents", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/private/ws/position_events.go
+++ b/api/private/ws/position_events.go
@@ -12,6 +12,9 @@ type PositionEvents interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.PositionEventsRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.PositionEventsRes
 }
 
@@ -42,6 +45,11 @@ func (c *positionEvents) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *positionEvents) Stream() <-chan *model.PositionEventsRes {
+	return api.RetrieveStreamOnce[model.PositionEventsRes](c.apiBase.WS(), "PositionEvents")
+}
+
+// Deprecated: use Stream instead.
 func (c *positionEvents) Receive() <-chan *model.PositionEventsRes {
-	return api.RetrieveStream[model.PositionEventsRes]("PositionEvents", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/private/ws/position_summary_events.go
+++ b/api/private/ws/position_summary_events.go
@@ -12,6 +12,9 @@ type PositionSummaryEvents interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.PositionSummaryEventsRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.PositionSummaryEventsRes
 }
 
@@ -43,6 +46,11 @@ func (c *positionSummaryEvents) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *positionSummaryEvents) Stream() <-chan *model.PositionSummaryEventsRes {
+	return api.RetrieveStreamOnce[model.PositionSummaryEventsRes](c.apiBase.WS(), "PositionSummaryEvents")
+}
+
+// Deprecated: use Stream instead.
 func (c *positionSummaryEvents) Receive() <-chan *model.PositionSummaryEventsRes {
-	return api.RetrieveStream[model.PositionSummaryEventsRes]("PositionSummaryEvents", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/public/ws/orderbooks.go
+++ b/api/public/ws/orderbooks.go
@@ -11,6 +11,9 @@ type OrderBooks interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.OrderBooksRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.OrderBooksRes
 }
 
@@ -44,6 +47,11 @@ func (c *orderBooks) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *orderBooks) Stream() <-chan *model.OrderBooksRes {
+	return api.RetrieveStreamOnce[model.OrderBooksRes](c.apiBase, "OrderBooks")
+}
+
+// Deprecated: use Stream instead.
 func (c *orderBooks) Receive() <-chan *model.OrderBooksRes {
-	return api.RetrieveStream[model.OrderBooksRes]("OrderBooks", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/public/ws/ticker.go
+++ b/api/public/ws/ticker.go
@@ -11,6 +11,9 @@ type Ticker interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.TickerRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.TickerRes
 }
 
@@ -44,6 +47,11 @@ func (c *ticker) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *ticker) Stream() <-chan *model.TickerRes {
+	return api.RetrieveStreamOnce[model.TickerRes](c.apiBase, "Ticker")
+}
+
+// Deprecated: use Stream instead.
 func (c *ticker) Receive() <-chan *model.TickerRes {
-	return api.RetrieveStream[model.TickerRes]("Ticker", c.apiBase.Stream())
+	return c.Stream()
 }

--- a/api/public/ws/trades.go
+++ b/api/public/ws/trades.go
@@ -11,6 +11,9 @@ type Trades interface {
 	Subscribe() error
 	SubscribeWithContext(ctx context.Context) error
 	Unsubscribe() error
+	Stream() <-chan *model.TradesRes
+	// Deprecated: use Stream instead. Receive is kept as an alias for backward
+	// compatibility and will be removed in a future major release.
 	Receive() <-chan *model.TradesRes
 }
 
@@ -45,6 +48,11 @@ func (c *trades) Unsubscribe() error {
 	return c.apiBase.Unsubscribe()
 }
 
+func (c *trades) Stream() <-chan *model.TradesRes {
+	return api.RetrieveStreamOnce[model.TradesRes](c.apiBase, "Trades")
+}
+
+// Deprecated: use Stream instead.
 func (c *trades) Receive() <-chan *model.TradesRes {
-	return api.RetrieveStream[model.TradesRes]("Trades", c.apiBase.Stream())
+	return c.Stream()
 }


### PR DESCRIPTION
## 概要

WebSocket クライアントの受信 API を見直し、`RetrieveStream` の goroutine リークを修正します。

## 変更点

### 1. `Receive()` → `Stream()` への命名変更（後方互換あり）
- 受信用アクセサはチャネルを返すため、`Receive`（1件受信のように読める）より `Stream` の方が意図に合い、`WSAPIBase.Stream` とも揃います。
- `Receive()` は **deprecated エイリアス**として残し、`Stream()` に委譲。既存コードはそのまま動作します（メジャーバージョンアップ不要）。

### 2. `RetrieveStream` の goroutine リーク修正
- 旧実装は `v == nil` で終了する設計でしたが、生ストリーム（`WSAPIBase.stream`）は close されないため、`Unsubscribe` 後も `<-rawStream` で永久ブロックし goroutine がリークしていました。
- `context.Context` を受け取り、`ctx.Done()` で確実に終了＋出力チャネルを `close` するよう修正。
- `v, ok := <-rawStream` に変更し、空メッセージを nil 扱いする曖昧さも解消。送信側もキャンセル可能に。

### 3. 複数回呼び出し・再 Subscribe 対応（`RetrieveStreamOnce`）
- typed stream を **Subscribe セッション単位でメモ化**し、複数回呼んでも同一チャネルを共有（生ストリームの奪い合い／goroutine 増殖を防止）。
- メモは `WSAPIBase.start()`（=Subscribe 時）でリセットするため、`Subscribe → Unsubscribe → Subscribe` で古い（close 済み）チャネルではなく**新しいライブなチャネル**が返ります。

## テスト
`api/internal/api/functions_test.go` を追加（`-race` で pass）:
- ペイロードの unmarshal／配信
- 不正ペイロードのスキップ
- **ctx キャンセルで出力チャネルが close される（リーク修正の核心）**
- セッション内の複数呼び出しでチャネルを共有
- **再 Subscribe 後に別のライブなチャネルが返る**

`go build` / `go vet` / `go test ./...` すべてグリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)