### PR TITLE
fix: resolve undici Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5982,9 +5982,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
   },
   "overrides": {
     "@actions/http-client": {
-      "undici": "^6.24.0"
+      "undici": "^6.27.0"
+    },
+    "@semantic-release/github": {
+      "undici": "^7.28.0"
     },
     "npm": "^11.17.0"
   },


### PR DESCRIPTION
## Summary
Dependabot で検出された `undici`（npm, devDependencies の `semantic-release` 経由の推移的依存）の脆弱性を `overrides` のバージョン引き上げで修正します。`undici` は CI のリリース自動化でのみ使われ、配布される Go ライブラリには含まれません。

## 修正内容
`package.json` の `overrides` を更新し、`npm install` で lockfile を再生成しました。

| パス | 旧 | 新 |
|---|---|---|
| `@actions/http-client > undici` | 6.25.0 (`^6.24.0`) | **6.27.0** (`^6.27.0`) |
| `@semantic-release/github > undici` | 7.25.0 | **7.28.0** (`^7.28.0`) |

## 解消されるアラート（6件）
| Alert # | Severity | CVE |
|---|---|---|
| #73 | High | CVE-2026-9697 (SOCKS5 ProxyAgent TLS 検証バイパス) |
| #75 | High | CVE-2026-6734 (SOCKS5 クロスオリジンルーティング) |
| #74 | Medium | CVE-2026-9678 |
| #77 | Medium | CVE-2026-9679 |
| #76 | Low | CVE-2026-6733 |
| #79 | Low | CVE-2026-11525 |

## 残存するアラート（3件・upstream ブロック）
| Alert # | Severity | CVE |
|---|---|---|
| #84 | Medium | CVE-2026-9679 |
| #82 | Low | CVE-2026-6733 |
| #85 | Low | CVE-2026-11525 |

これらは `npm` パッケージが **bundledDependency として同梱する `undici@6.26.0`** に起因します。npm 最新の 11.17.0 でも 6.26.0 を同梱しており、npm の `overrides` では bundled 依存を置換できないため、**npm がパッチ済み undici（>= 6.27.0）を同梱する版をリリースするまで解消できません**。dev-scope のみ・`node-gyp` のネイティブビルド時専用で、純 Go ライブラリでは実行されず実リスクはほぼありません。対応案: upstream を追跡して npm 更新時に再 `npm install`、または該当 3 件を "tolerable risk" として dismiss。

## テスト
- [x] `npm install` で lockfile 再生成、依存整合性確認済み
- [x] `npm ls undici` で 6.27.0 / 7.28.0 / (npm-bundled 6.26.0) を確認
- [x] `npm audit` で残存が npm-bundled の 1 件のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)